### PR TITLE
Set 'this' context properly in FuncEventSource

### DIFF
--- a/src/models/event-source/FuncEventSource.js
+++ b/src/models/event-source/FuncEventSource.js
@@ -9,7 +9,7 @@ var FuncEventSource = EventSource.extend({
 
 		return Promise.construct(function(onResolve) {
 			_this.func.call(
-				this.calendar,
+				_this.calendar,
 				start.clone(),
 				end.clone(),
 				timezone,


### PR DESCRIPTION
The current code sets the `this` context when invoking the user-defined event source function. However it uses `this.calendar`, which is undefined in the `Promise` callback. It should be using `_this` to access the correct context.